### PR TITLE
Avoid using deprecated Buffer API

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,12 @@ var eos = require('end-of-stream')
 var inherits = require('inherits')
 var shift = require('stream-shift')
 
-var SIGNAL_FLUSH = new Buffer([0])
+var SIGNAL_FLUSH
+if (Buffer.from && Buffer.from !== Uint8Array.from) {
+  SIGNAL_FLUSH = Buffer.from([0])
+} else {
+  SIGNAL_FLUSH = new Buffer([0])
+}
 
 var onuncork = function(self, fn) {
   if (self._corked) self.once('uncork', fn)


### PR DESCRIPTION
Use Buffer.from when it's available instead of 'new Bufer(arr)'

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

This is one of the three changes needed to keep `npm i` working under `NODE_PENDING_DEPRECATION=1` without warnings. The other two are https://github.com/mafintosh/flush-write-stream/pull/3 and https://github.com/npm/node-tar/pull/175.