### PR TITLE
end writable stream when destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ Duplexify.prototype._destroy = function(err) {
 
   if (this._forwardDestroy) {
     if (this._readable && this._readable.destroy) this._readable.destroy()
-    if (this._writable && this._writable.destroy) this._writable.destroy()
+    if (this._writable && this._writable.destroy) this._writable.end()
   }
 
   this.emit('close')

--- a/test.js
+++ b/test.js
@@ -126,8 +126,8 @@ tape('destroy', function(t) {
   var read = through()
   var dup = duplexify(write, read)
 
-  write.destroy = function() {
-    t.ok(true, 'write destroyed')
+  write.end = function() {
+    t.ok(true, 'write ended')
   }
 
   dup.on('close', function() {
@@ -145,8 +145,8 @@ tape('destroy both', function(t) {
   var read = through()
   var dup = duplexify(write, read)
 
-  write.destroy = function() {
-    t.ok(true, 'write destroyed')
+  write.end = function() {
+    t.ok(true, 'write ended')
   }
 
   read.destroy = function() {
@@ -160,6 +160,22 @@ tape('destroy both', function(t) {
   dup.destroy()
   dup.destroy() // should only work once
 })
+
+tape('end writable stream when destroyed', function(t) {
+  t.plan(1)
+  t.timeoutAfter(5000)
+
+  var write = through()
+  var read = through()
+  var dup = duplexify(write, read)
+
+  write.end = function() {
+    t.ok(true, 'write ended')
+  }
+
+  dup.destroy()
+})
+
 
 tape('bubble read errors', function(t) {
   t.plan(2)

--- a/test.js
+++ b/test.js
@@ -161,22 +161,6 @@ tape('destroy both', function(t) {
   dup.destroy() // should only work once
 })
 
-tape('end writable stream when destroyed', function(t) {
-  t.plan(1)
-  t.timeoutAfter(5000)
-
-  var write = through()
-  var read = through()
-  var dup = duplexify(write, read)
-
-  write.end = function() {
-    t.ok(true, 'write ended')
-  }
-
-  dup.destroy()
-})
-
-
 tape('bubble read errors', function(t) {
   t.plan(2)
 


### PR DESCRIPTION
I started seeing "Cannot call write after a stream was destroyed" when I call `aDuplexifyStream.destroy()` with the upgrade to duplexify@4. The latest readable-stream incorporates Node v10 Stream behavior. The recommendation from the Node docs is:

> ## [writable.destroy([error])](https://nodejs.org/api/stream.html#stream_writable_destroy_error)
> [...] After this call, the writable stream has ended and subsequent calls to `write()` or `end()` will result in an `ERR_STREAM_DESTROYED` error. This is a destructive and immediate way to destroy a stream. Previous calls to `write()` may not have drained, and may trigger an `ERR_STREAM_DESTROYED` error. Use `end()` instead of destroy if data should flush before close, or wait for the `'drain'` event before destroying the stream.

I went with `end()`. Happy to make any changes!