### PR TITLE
add typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export interface DuplexifyOptions extends DuplexOptions {
   end?: boolean;
 }
 
-export class Duplexify extends Duplex {
+export interface Duplexify extends Duplex {
   readonly destroyed: boolean;
   setWritable(writable: Writable|false|null): void;
   setReadable(readable: Readable|false|null): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="node"/>
+import {Duplex, DuplexOptions, Readable, Writable} from 'stream';
+
+export interface DuplexifyOptions extends DuplexOptions {
+  autoDestroy?: boolean;
+  end?: boolean;
+}
+
+export class Duplexify extends Duplex {
+  readonly destroyed: boolean;
+  setWritable(writable: Writable|false|null): void;
+  setReadable(readable: Readable|false|null): void;
+}
+
+interface DuplexifyConstructor {
+  obj(writable?: Writable|false|null, readable?: Readable|false|null, options?: DuplexifyOptions): Duplexify;
+  new (writable?: Writable|false|null, readable?: Readable|false|null, options?: DuplexifyOptions): Duplexify;
+  (writable?: Writable|false|null, readable?: Readable|false|null, options?: DuplexifyOptions): Duplexify;
+}
+
+declare var duplexify: DuplexifyConstructor;
+
+export default duplexify;

--- a/index.js
+++ b/index.js
@@ -232,3 +232,4 @@ Duplexify.prototype.end = function(data, enc, cb) {
 }
 
 module.exports = Duplexify
+module.exports.default = Duplexify;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import {expectType} from 'tsd-check';
+import {expectType} from 'tsd';
 import {Readable, Writable} from 'stream';
 import duplexify, {Duplexify, DuplexifyOptions} from '.';
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,39 @@
+import {expectType} from 'tsd-check';
+import {Readable, Writable} from 'stream';
+import duplexify, {Duplexify, DuplexifyOptions} from '.';
+
+const readable = new Readable({read: () => {}});
+const writable = new Writable({write: () => {}});
+const options: DuplexifyOptions = {highWaterMark: 6};
+
+expectType<Duplexify>(new duplexify());
+expectType<Duplexify>(new duplexify(null));
+expectType<Duplexify>(new duplexify(null, null));
+expectType<Duplexify>(new duplexify(false, false));
+expectType<Duplexify>(new duplexify(writable, readable, options));
+
+expectType<Duplexify>(duplexify());
+expectType<Duplexify>(duplexify(null));
+expectType<Duplexify>(duplexify(null, null));
+expectType<Duplexify>(duplexify(false, false));
+expectType<Duplexify>(duplexify(writable, readable, options));
+
+expectType<Duplexify>(duplexify.obj());
+expectType<Duplexify>(duplexify.obj(null));
+expectType<Duplexify>(duplexify.obj(null, null));
+expectType<Duplexify>(duplexify.obj(false, false));
+expectType<Duplexify>(duplexify.obj(writable, readable, options));
+
+expectType<boolean>(duplexify().destroyed);
+
+expectType<void>(duplexify().setWritable(null));
+expectType<void>(duplexify().setWritable(false));
+expectType<void>(duplexify().setWritable(writable));
+
+expectType<void>(duplexify().setReadable(null));
+expectType<void>(duplexify().setReadable(false));
+expectType<void>(duplexify().setReadable(readable));
+
+class MyDuplex extends duplexify {}
+const duplex = new MyDuplex();
+expectType<void>(duplex.setWritable(null));

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "concat-stream": "^1.5.2",
     "tape": "^4.0.0",
     "through2": "^2.0.0",
-    "tsd-check": "^0.3.0"
+    "tsd": "^0.7.0"
   },
   "scripts": {
-    "test": "tape test.js && tsd-check"
+    "test": "tape test.js && tsd"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "stream-shift": "^1.0.0"
   },
   "devDependencies": {
+    "@types/node": "^11.11.1",
     "concat-stream": "^1.5.2",
     "tape": "^4.0.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "tsd-check": "^0.3.0"
   },
   "scripts": {
-    "test": "tape test.js"
+    "test": "tape test.js && tsd-check"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #24

I should probably mention that I'm probably not the best person to do this, please be gentle!

I had some issues trying to subclass duplexify with the `@types/duplexify` module, I believe what I'm proposing will allow it to be done and remove the need for a wildcard import. Since I've added a default export, I think this is going to blow up anyone's project that is using `@types/duplexify` though.