### PR TITLE
Fix 'Cannot call write after a stream was destroyed'

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,13 +200,13 @@ Duplexify.prototype._destroy = function(err) {
 }
 
 Duplexify.prototype._write = function(data, enc, cb) {
-  if (this.destroyed) return cb()
+  if (this.destroyed) return
   if (this._corked) return onuncork(this, this._write.bind(this, data, enc, cb))
   if (data === SIGNAL_FLUSH) return this._finish(cb)
   if (!this._writable) return cb()
 
   if (this._writable.write(data) === false) this._ondrain = cb
-  else cb()
+  else if (!this.destroyed) cb()
 }
 
 Duplexify.prototype._finish = function(cb) {


### PR DESCRIPTION
Related to #27, I found a new edge case.

This PR adds two tests and a fix. Without the fix, the first test would fail with 'Cannot call write after a stream was destroyed'. The second test is to ensure the other code path still works, that is:

https://github.com/mafintosh/duplexify/blob/9dc80c1387d92270f2878c467e84a897973a71f7/index.js#L208

Followed by:

https://github.com/mafintosh/duplexify/blob/9dc80c1387d92270f2878c467e84a897973a71f7/index.js#L190