### PR TITLE
Added support for .destroy(err, cb) signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,22 +173,14 @@ Duplexify.prototype._forward = function() {
   this._forwarding = false
 }
 
-Duplexify.prototype.destroy = function(err) {
-  if (this.destroyed) return
-  this.destroyed = true
-
-  var self = this
-  process.nextTick(function() {
-    self._destroy(err)
-  })
-}
-
-Duplexify.prototype._destroy = function(err) {
+Duplexify.prototype._destroy = function(err, cb) {
   if (err) {
     var ondrain = this._ondrain
     this._ondrain = null
-    if (ondrain) ondrain(err)
-    else this.emit('error', err)
+    if (ondrain) {
+      ondrain(err)
+      err = null
+    }
   }
 
   if (this._forwardDestroy) {
@@ -196,7 +188,7 @@ Duplexify.prototype._destroy = function(err) {
     if (this._writable && this._writable.destroy) this._writable.destroy()
   }
 
-  this.emit('close')
+  cb(err)
 }
 
 Duplexify.prototype._write = function(data, enc, cb) {

--- a/test.js
+++ b/test.js
@@ -336,3 +336,16 @@ tape('works with node native streams (net)', function(t) {
     dup.write(HELLO_WORLD)
   })
 })
+
+tape('destroy with a callback', function(t) {
+  t.plan(1)
+
+  var write = through()
+  var read = through()
+  var dup = duplexify(write, read)
+
+  var e = new Error('kaboom')
+  dup.destroy(e, function (err) {
+    t.strictEqual(err, e)
+  })
+})


### PR DESCRIPTION
Remove the internal destroy implementation and use the readable-stream@3 one.

See https://github.com/mafintosh/pumpify/issues/11.