### PR TITLE
Specify files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   "bugs": {
     "url": "https://github.com/mafintosh/duplexify/issues"
   },
-  "homepage": "https://github.com/mafintosh/duplexify"
+  "homepage": "https://github.com/mafintosh/duplexify",
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Currently the test file and the example file are also being published to npm. Considering that they make up more than half of the filesize of this package, it would be worthwhile to not publish them. This PR does this using the [`files`](https://docs.npmjs.com/files/package.json#files) field in the `package.json`. 