### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - "4"
   - "6"


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
