### PR TITLE
Modernize codebase

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,17 +1,17 @@
-var duplexify = require('duplexify')
-var http = require('http')
+const duplexify = require('duplexify')
+const http = require('http')
 
-var request = function(opts) {
-  var req = http.request(opts)
-  var dup = duplexify()
+const request = function (opts) {
+  const req = http.request(opts)
+  const dup = duplexify()
   dup.setWritable(req)
-  req.on('response', function(res) {
+  req.on('response', function (res) {
     dup.setReadable(res)
   })
   return dup
 }
 
-var req = request({
+const req = request({
   method: 'GET',
   host: 'www.google.com',
   port: 80

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { Duplex, Readable, Writable } = require('readable-stream')
+const { Duplex, Readable, Writable } = require('stream')
 const eos = require('end-of-stream')
 const shift = require('stream-shift')
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var stream = require('readable-stream')
 var eos = require('end-of-stream')
-var inherits = require('inherits')
 var shift = require('stream-shift')
 
 var SIGNAL_FLUSH = (Buffer.from && Buffer.from !== Uint8Array.from)

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ function end (ws, fn) {
   fn()
 }
 
-/** @param {Readable} rs */
 function toStreams2 (rs) {
   return new Readable({ objectMode: true, highWaterMark: 16 }).wrap(rs)
 }
@@ -67,10 +66,14 @@ class Duplexing extends Duplex {
   }
 
   setWritable (writable) {
-    if (this._unwrite) { this._unwrite() }
+    if (this._unwrite) {
+      this._unwrite()
+    }
 
     if (this.destroyed) {
-      if (writable && writable.destroy) { writable.destroy() }
+      if (writable && writable.destroy) {
+        writable.destroy()
+      }
       return
     }
 
@@ -79,7 +82,10 @@ class Duplexing extends Duplex {
       return
     }
 
-    const unend = eos(writable, { writable: true, readable: false }, destroyer(this, this._forwardEnd))
+    const unend = eos(writable, {
+      writable: true,
+      readable: false
+    }, destroyer(this, this._forwardEnd))
 
     const ondrain = () => {
       const ondrain = this._ondrain
@@ -92,7 +98,10 @@ class Duplexing extends Duplex {
       unend()
     }
 
-    if (this._unwrite) { process.nextTick(ondrain) } // force a drain on stream reset to avoid livelocks
+    if (this._unwrite) {
+      // force a drain on stream reset to avoid livelocks
+      process.nextTick(ondrain)
+    }
 
     this._writable = writable
     this._writable.on('drain', ondrain)
@@ -105,7 +114,9 @@ class Duplexing extends Duplex {
     if (this._unread) { this._unread() }
 
     if (this.destroyed) {
-      if (readable && readable.destroy) { readable.destroy() }
+      if (readable && readable.destroy) {
+        readable.destroy()
+      }
       return
     }
 
@@ -136,7 +147,9 @@ class Duplexing extends Duplex {
 
     this._drained = true
     this._readable = readable
-    this._readable2 = readable._readableState ? readable : toStreams2(readable)
+    this._readable2 = readable._readableState
+      ? readable
+      : toStreams2(readable)
     this._readable2.on('readable', onreadable)
     this._readable2.on('end', onend)
     this._unread = clear
@@ -150,7 +163,10 @@ class Duplexing extends Duplex {
   }
 
   _forward () {
-    if (this._forwarding || !this._readable2 || !this._drained) { return }
+    if (this._forwarding || !this._readable2 || !this._drained) {
+      return
+    }
+
     this._forwarding = true
 
     let data
@@ -164,7 +180,10 @@ class Duplexing extends Duplex {
   }
 
   destroy (err, cb) {
-    if (this.destroyed) { return cb && cb(null) }
+    if (this.destroyed) {
+      return cb && cb(null)
+    }
+
     this.destroyed = true
 
     process.nextTick(() => {
@@ -177,12 +196,18 @@ class Duplexing extends Duplex {
     if (err) {
       const ondrain = this._ondrain
       this._ondrain = null
+
       if (ondrain) { ondrain(err) } else { this.emit('error', err) }
     }
 
     if (this._forwardDestroy) {
-      if (this._readable && this._readable.destroy) { this._readable.destroy() }
-      if (this._writable && this._writable.destroy) { this._writable.destroy() }
+      if (this._readable && this._readable.destroy) {
+        this._readable.destroy()
+      }
+
+      if (this._writable && this._writable.destroy) {
+        this._writable.destroy()
+      }
     }
 
     this.emit('close')
@@ -190,11 +215,22 @@ class Duplexing extends Duplex {
 
   _write (data, enc, cb) {
     if (this.destroyed) { return }
-    if (this._corked) { return onuncork(this, this._write.bind(this, data, enc, cb)) }
-    if (data === SIGNAL_FLUSH) { return this._finish(cb) }
-    if (!this._writable) { return cb() }
+    if (this._corked) {
+      return onuncork(this, this._write.bind(this, data, enc, cb))
+    }
+    if (data === SIGNAL_FLUSH) {
+      return this._finish(cb)
+    }
 
-    if (this._writable.write(data) === false) { this._ondrain = cb } else if (!this.destroyed) { cb() }
+    if (!this._writable) {
+      return cb()
+    }
+
+    if (this._writable.write(data) === false) {
+      this._ondrain = cb
+    } else if (!this.destroyed) {
+      cb()
+    }
   }
 
   _finish (cb) {
@@ -213,11 +249,17 @@ class Duplexing extends Duplex {
   }
 
   end (data, enc, cb) {
-    if (typeof data === 'function') { return this.end(null, null, data) }
-    if (typeof enc === 'function') { return this.end(data, null, enc) }
+    if (typeof data === 'function') return this.end(null, null, data)
+    if (typeof enc === 'function') return this.end(data, null, enc)
+
     this._ended = true
-    if (data) { this.write(data) }
-    if (!this._writableState.ending && !this._writableState.destroyed) { this.write(SIGNAL_FLUSH) }
+
+    if (data) this.write(data)
+
+    if (!this._writableState.ending && !this._writableState.destroyed) {
+      this.write(SIGNAL_FLUSH)
+    }
+
     return Writable.prototype.end.call(this, cb)
   }
 

--- a/index.js
+++ b/index.js
@@ -251,4 +251,10 @@ class Duplexing extends stream.Duplex {
   }
 }
 
-module.exports = Duplexify
+// Use proxy to call class constructor without new keyword
+// For backward compatibility
+module.exports = new Proxy(Duplexing, {
+  apply (target, thisArg, argumentsList) {
+    return new target(...argumentsList);
+  }
+})

--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@ var stream = require('readable-stream')
 var eos = require('end-of-stream')
 var shift = require('stream-shift')
 
-var SIGNAL_FLUSH = (Buffer.from && Buffer.from !== Uint8Array.from)
-  ? Buffer.from([0])
-  : new Buffer([0])
+var SIGNAL_FLUSH = Buffer.from([0])
 
 var onuncork = function(self, fn) {
   if (self._corked) self.once('uncork', fn)
@@ -36,202 +34,221 @@ var toStreams2 = function(rs) {
   return new (stream.Readable)({objectMode:true, highWaterMark:16}).wrap(rs)
 }
 
-var Duplexify = function(writable, readable, opts) {
-  if (!(this instanceof Duplexify)) return new Duplexify(writable, readable, opts)
-  stream.Duplex.call(this, opts)
+class Duplexing extends stream.Duplex {
+  constructor (writable, readable, opts) {
+    super(opts)
 
-  this._writable = null
-  this._readable = null
-  this._readable2 = null
+    this._writable = null
+    this._readable = null
+    this._readable2 = null
 
-  this._autoDestroy = !opts || opts.autoDestroy !== false
-  this._forwardDestroy = !opts || opts.destroy !== false
-  this._forwardEnd = !opts || opts.end !== false
-  this._corked = 1 // start corked
-  this._ondrain = null
-  this._drained = false
-  this._forwarding = false
-  this._unwrite = null
-  this._unread = null
-  this._ended = false
-
-  this.destroyed = false
-
-  if (writable) this.setWritable(writable)
-  if (readable) this.setReadable(readable)
-}
-
-inherits(Duplexify, stream.Duplex)
-
-Duplexify.obj = function(writable, readable, opts) {
-  if (!opts) opts = {}
-  opts.objectMode = true
-  opts.highWaterMark = 16
-  return new Duplexify(writable, readable, opts)
-}
-
-Duplexify.prototype.cork = function() {
-  if (++this._corked === 1) this.emit('cork')
-}
-
-Duplexify.prototype.uncork = function() {
-  if (this._corked && --this._corked === 0) this.emit('uncork')
-}
-
-Duplexify.prototype.setWritable = function(writable) {
-  if (this._unwrite) this._unwrite()
-
-  if (this.destroyed) {
-    if (writable && writable.destroy) writable.destroy()
-    return
-  }
-
-  if (writable === null || writable === false) {
-    this.end()
-    return
-  }
-
-  var self = this
-  var unend = eos(writable, {writable:true, readable:false}, destroyer(this, this._forwardEnd))
-
-  var ondrain = function() {
-    var ondrain = self._ondrain
-    self._ondrain = null
-    if (ondrain) ondrain()
-  }
-
-  var clear = function() {
-    self._writable.removeListener('drain', ondrain)
-    unend()
-  }
-
-  if (this._unwrite) process.nextTick(ondrain) // force a drain on stream reset to avoid livelocks
-
-  this._writable = writable
-  this._writable.on('drain', ondrain)
-  this._unwrite = clear
-
-  this.uncork() // always uncork setWritable
-}
-
-Duplexify.prototype.setReadable = function(readable) {
-  if (this._unread) this._unread()
-
-  if (this.destroyed) {
-    if (readable && readable.destroy) readable.destroy()
-    return
-  }
-
-  if (readable === null || readable === false) {
-    this.push(null)
-    this.resume()
-    return
-  }
-
-  var self = this
-  var unend = eos(readable, {writable:false, readable:true}, destroyer(this))
-
-  var onreadable = function() {
-    self._forward()
-  }
-
-  var onend = function() {
-    self.push(null)
-  }
-
-  var clear = function() {
-    self._readable2.removeListener('readable', onreadable)
-    self._readable2.removeListener('end', onend)
-    unend()
-  }
-
-  this._drained = true
-  this._readable = readable
-  this._readable2 = readable._readableState ? readable : toStreams2(readable)
-  this._readable2.on('readable', onreadable)
-  this._readable2.on('end', onend)
-  this._unread = clear
-
-  this._forward()
-}
-
-Duplexify.prototype._read = function() {
-  this._drained = true
-  this._forward()
-}
-
-Duplexify.prototype._forward = function() {
-  if (this._forwarding || !this._readable2 || !this._drained) return
-  this._forwarding = true
-
-  var data
-
-  while (this._drained && (data = shift(this._readable2)) !== null) {
-    if (this.destroyed) continue
-    this._drained = this.push(data)
-  }
-
-  this._forwarding = false
-}
-
-Duplexify.prototype.destroy = function(err, cb) {
-  if (!cb) cb = noop
-  if (this.destroyed) return cb(null)
-  this.destroyed = true
-
-  var self = this
-  process.nextTick(function() {
-    self._destroy(err)
-    cb(null)
-  })
-}
-
-Duplexify.prototype._destroy = function(err) {
-  if (err) {
-    var ondrain = this._ondrain
+    this._autoDestroy = !opts || opts.autoDestroy !== false
+    this._forwardDestroy = !opts || opts.destroy !== false
+    this._forwardEnd = !opts || opts.end !== false
+    this._corked = 1 // start corked
     this._ondrain = null
-    if (ondrain) ondrain(err)
-    else this.emit('error', err)
+    this._drained = false
+    this._forwarding = false
+    this._unwrite = null
+    this._unread = null
+    this._ended = false
+
+    this.destroyed = false
+
+    if (writable)
+      this.setWritable(writable)
+    if (readable)
+      this.setReadable(readable)
   }
-
-  if (this._forwardDestroy) {
-    if (this._readable && this._readable.destroy) this._readable.destroy()
-    if (this._writable && this._writable.destroy) this._writable.destroy()
+  cork() {
+    if (++this._corked === 1)
+      this.emit('cork')
   }
+  uncork() {
+    if (this._corked && --this._corked === 0)
+      this.emit('uncork')
+  }
+  setWritable(writable) {
+    if (this._unwrite)
+      this._unwrite()
 
-  this.emit('close')
-}
+    if (this.destroyed) {
+      if (writable && writable.destroy)
+        writable.destroy()
+      return
+    }
 
-Duplexify.prototype._write = function(data, enc, cb) {
-  if (this.destroyed) return
-  if (this._corked) return onuncork(this, this._write.bind(this, data, enc, cb))
-  if (data === SIGNAL_FLUSH) return this._finish(cb)
-  if (!this._writable) return cb()
+    if (writable === null || writable === false) {
+      this.end()
+      return
+    }
 
-  if (this._writable.write(data) === false) this._ondrain = cb
-  else if (!this.destroyed) cb()
-}
+    var self = this
+    var unend = eos(writable, { writable: true, readable: false }, destroyer(this, this._forwardEnd))
 
-Duplexify.prototype._finish = function(cb) {
-  var self = this
-  this.emit('preend')
-  onuncork(this, function() {
-    end(self._forwardEnd && self._writable, function() {
-      // haxx to not emit prefinish twice
-      if (self._writableState.prefinished === false) self._writableState.prefinished = true
-      self.emit('prefinish')
-      onuncork(self, cb)
+    var ondrain = function () {
+      var ondrain = self._ondrain
+      self._ondrain = null
+      if (ondrain)
+        ondrain()
+    }
+
+    var clear = function () {
+      self._writable.removeListener('drain', ondrain)
+      unend()
+    }
+
+    if (this._unwrite)
+      process.nextTick(ondrain) // force a drain on stream reset to avoid livelocks
+
+    this._writable = writable
+    this._writable.on('drain', ondrain)
+    this._unwrite = clear
+
+    this.uncork() // always uncork setWritable
+  }
+  setReadable(readable) {
+    if (this._unread)
+      this._unread()
+
+    if (this.destroyed) {
+      if (readable && readable.destroy)
+        readable.destroy()
+      return
+    }
+
+    if (readable === null || readable === false) {
+      this.push(null)
+      this.resume()
+      return
+    }
+
+    var self = this
+    var unend = eos(readable, { writable: false, readable: true }, destroyer(this))
+
+    var onreadable = function () {
+      self._forward()
+    }
+
+    var onend = function () {
+      self.push(null)
+    }
+
+    var clear = function () {
+      self._readable2.removeListener('readable', onreadable)
+      self._readable2.removeListener('end', onend)
+      unend()
+    }
+
+    this._drained = true
+    this._readable = readable
+    this._readable2 = readable._readableState ? readable : toStreams2(readable)
+    this._readable2.on('readable', onreadable)
+    this._readable2.on('end', onend)
+    this._unread = clear
+
+    this._forward()
+  }
+  _read() {
+    this._drained = true
+    this._forward()
+  }
+  _forward() {
+    if (this._forwarding || !this._readable2 || !this._drained)
+      return
+    this._forwarding = true
+
+    var data
+
+    while (this._drained && (data = shift(this._readable2)) !== null) {
+      if (this.destroyed)
+        continue
+      this._drained = this.push(data)
+    }
+
+    this._forwarding = false
+  }
+  destroy(err, cb) {
+    if (!cb)
+      cb = noop
+    if (this.destroyed)
+      return cb(null)
+    this.destroyed = true
+
+    var self = this
+    process.nextTick(function () {
+      self._destroy(err)
+      cb(null)
     })
-  })
-}
+  }
+  _destroy(err) {
+    if (err) {
+      var ondrain = this._ondrain
+      this._ondrain = null
+      if (ondrain)
+        ondrain(err)
+      else
+        this.emit('error', err)
+    }
 
-Duplexify.prototype.end = function(data, enc, cb) {
-  if (typeof data === 'function') return this.end(null, null, data)
-  if (typeof enc === 'function') return this.end(data, null, enc)
-  this._ended = true
-  if (data) this.write(data)
-  if (!this._writableState.ending && !this._writableState.destroyed) this.write(SIGNAL_FLUSH)
-  return stream.Writable.prototype.end.call(this, cb)
+    if (this._forwardDestroy) {
+      if (this._readable && this._readable.destroy)
+        this._readable.destroy()
+      if (this._writable && this._writable.destroy)
+        this._writable.destroy()
+    }
+
+    this.emit('close')
+  }
+  _write(data, enc, cb) {
+    if (this.destroyed)
+      return
+    if (this._corked)
+      return onuncork(this, this._write.bind(this, data, enc, cb))
+    if (data === SIGNAL_FLUSH)
+      return this._finish(cb)
+    if (!this._writable)
+      return cb()
+
+    if (this._writable.write(data) === false)
+      this._ondrain = cb
+    else if (!this.destroyed)
+      cb()
+  }
+  _finish(cb) {
+    var self = this
+    this.emit('preend')
+    onuncork(this, function () {
+      end(self._forwardEnd && self._writable, function () {
+        // haxx to not emit prefinish twice
+        if (self._writableState.prefinished === false)
+          self._writableState.prefinished = true
+        self.emit('prefinish')
+        onuncork(self, cb)
+      })
+    })
+  }
+
+  end(data, enc, cb) {
+    if (typeof data === 'function')
+      return this.end(null, null, data)
+    if (typeof enc === 'function')
+      return this.end(data, null, enc)
+    this._ended = true
+    if (data)
+      this.write(data)
+    if (!this._writableState.ending && !this._writableState.destroyed)
+      this.write(SIGNAL_FLUSH)
+    return stream.Writable.prototype.end.call(this, cb)
+  }
+
+  static obj(writable, readable, opts) {
+    if (!opts)
+      opts = {}
+    opts.objectMode = true
+    opts.highWaterMark = 16
+    return new Duplexing(writable, readable, opts)
+  }
 }
 
 module.exports = Duplexify

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { Duplex, Readable, Writable } = require('stream')
+const { Buffer } = require('buffer')
 const eos = require('end-of-stream')
 const shift = require('stream-shift')
 

--- a/index.js
+++ b/index.js
@@ -163,8 +163,7 @@ class Duplexing extends stream.Duplex {
     this._forwarding = false
   }
 
-  destroy (err, cb) {
-    if (!cb) { cb = noop }
+  destroy (err, cb = noop) {
     if (this.destroyed) { return cb(null) }
     this.destroyed = true
 
@@ -221,8 +220,7 @@ class Duplexing extends stream.Duplex {
     return stream.Writable.prototype.end.call(this, cb)
   }
 
-  static obj (writable, readable, opts) {
-    if (!opts) { opts = {} }
+  static obj (writable, readable, opts = {}) {
     opts.objectMode = true
     opts.highWaterMark = 16
     return new Duplexing(writable, readable, opts)

--- a/index.js
+++ b/index.js
@@ -4,23 +4,23 @@ const shift = require('stream-shift')
 
 const SIGNAL_FLUSH = Buffer.from([0])
 
-const onuncork = function (ctx, fn) {
+function onuncork (ctx, fn) {
   if (ctx._corked) ctx.once('uncork', fn)
   else fn()
 }
 
-const autoDestroy = function (ctx, err) {
+function autoDestroy (ctx, err) {
   if (ctx._autoDestroy) ctx.destroy(err)
 }
 
-const destroyer = function (ctx, end) {
+function destroyer (ctx, end) {
   return function (err) {
     if (err) autoDestroy(ctx, err.message === 'premature close' ? null : err)
     else if (end && !ctx._ended) ctx.end()
   }
 }
 
-const end = function (ws, fn) {
+function end (ws, fn) {
   if (!ws) return fn()
   if (ws._writableState && ws._writableState.finished) return fn()
   if (ws._writableState) return ws.end(fn)
@@ -28,7 +28,8 @@ const end = function (ws, fn) {
   fn()
 }
 
-const toStreams2 = function (rs) {
+/** @param {Readable} rs */
+function toStreams2 (rs) {
   return new Readable({ objectMode: true, highWaterMark: 16 }).wrap(rs)
 }
 
@@ -230,7 +231,7 @@ class Duplexing extends Duplex {
 // Use proxy to call class constructor without new keyword
 // For backward compatibility
 module.exports = new Proxy(Duplexing, {
-  apply (target, thisArg, argumentsList) {
-    return new target(...argumentsList)
+  apply (Target, thisArg, argumentsList) {
+    return new Target(...argumentsList)
   }
 })

--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ const end = function (ws, fn) {
   fn()
 }
 
-const noop = function () {}
-
 const toStreams2 = function (rs) {
   return new Readable({ objectMode: true, highWaterMark: 16 }).wrap(rs)
 }
@@ -163,14 +161,14 @@ class Duplexing extends Duplex {
     this._forwarding = false
   }
 
-  destroy (err, cb = noop) {
-    if (this.destroyed) { return cb(null) }
+  destroy (err, cb) {
+    if (this.destroyed) { return cb && cb(null) }
     this.destroyed = true
 
     const self = this
     process.nextTick(function () {
       self._destroy(err)
-      cb(null)
+      cb && cb(null)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const stream = require('readable-stream')
+const { Duplex, Readable, Writable } = require('readable-stream')
 const eos = require('end-of-stream')
 const shift = require('stream-shift')
 
@@ -31,10 +31,10 @@ const end = function (ws, fn) {
 const noop = function () {}
 
 const toStreams2 = function (rs) {
-  return new stream.Readable({ objectMode: true, highWaterMark: 16 }).wrap(rs)
+  return new Readable({ objectMode: true, highWaterMark: 16 }).wrap(rs)
 }
 
-class Duplexing extends stream.Duplex {
+class Duplexing extends Duplex {
   constructor (writable, readable, opts) {
     super(opts)
 
@@ -217,7 +217,7 @@ class Duplexing extends stream.Duplex {
     this._ended = true
     if (data) { this.write(data) }
     if (!this._writableState.ending && !this._writableState.destroyed) { this.write(SIGNAL_FLUSH) }
-    return stream.Writable.prototype.end.call(this, cb)
+    return Writable.prototype.end.call(this, cb)
   }
 
   static obj (writable, readable, opts = {}) {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
   "main": "index.js",
   "dependencies": {
-    "end-of-stream": "^1.4.1",
-    "readable-stream": "^3.1.1",
-    "stream-shift": "^1.0.0"
+    "end-of-stream": "^1.4.4",
+    "readable-stream": "^3.6.0",
+    "stream-shift": "^1.0.1"
   },
   "devDependencies": {
-    "concat-stream": "^1.5.2",
-    "tape": "^4.0.0",
-    "through2": "^2.0.0"
+    "concat-stream": "^2.0.0",
+    "tape": "^5.3.1",
+    "through2": "^4.0.2"
   },
   "scripts": {
     "test": "tape test.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "end-of-stream": "^1.4.4",
-    "readable-stream": "^3.6.0",
     "stream-shift": "^1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "end-of-stream": "^1.4.1",
-    "inherits": "^2.0.3",
     "readable-stream": "^3.1.1",
     "stream-shift": "^1.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var tape = require('tape')
 var through = require('through2')
 var concat = require('concat-stream')
-var stream = require('readable-stream')
+var stream = require('stream')
 var net = require('net')
 var duplexify = require('./')
 


### PR DESCRIPTION
Summary:

- Updated all dep
- Switched to const, let, class + extend
- removed inherits and writable-stream
- depends on builtin stream + buffer instead of polyfill (to always get newest version and fewer dependency installs)
- tested using `standard --fix index.js && npx node@10 index.js && npm run test`
 - The hole test file remains the same to prove that everything works as before (only change was to use `node:stream` instead) 
- know u use standard.js in some projects so i applied it using latest (16) version
- it no longer use `new Buffer()` constructor
- update code examples in readme

closes #35

