### PR TITLE
fix: Cannot read properties of null (reading length) in stream-shift

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "end-of-stream": "^1.4.1",
     "inherits": "^2.0.3",
     "readable-stream": "^3.1.1",
-    "stream-shift": "^1.0.0"
+    "stream-shift": "^1.0.2"
   },
   "devDependencies": {
     "concat-stream": "^1.5.2",


### PR DESCRIPTION
I ran into this issue https://github.com/mafintosh/stream-shift/issues/6 using https://www.npmjs.com/package/@google-cloud/storage. It has been resolved in https://github.com/mafintosh/stream-shift/pull/7, would be great to get this merged. I'll open another PR on `@google-cloud/storage` once there's a new version. Thanks!